### PR TITLE
Fixed workflow scripts

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -6,7 +6,7 @@
 name: Linter
 
 on:
-  push:
+  pull_request:
     branches:
       - '*'
 
@@ -20,8 +20,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --write **/*.md
+          dry: true


### PR DESCRIPTION
Since the branch has been renamed, had to add some extra fixes to the workflow script to make it work.

There are two scripts:
1. lint.yml: Those who have workflows enabled on their forks, it will prettify their code automatically
2. pr-lint.yml: Since the Prettier Bot cannot run on a PR (because no one has write privileges to PR, but the author), only doing a dry run to check if the code needs to be prettified or not. 